### PR TITLE
hey

### DIFF
--- a/lib/seer/geomap.rb
+++ b/lib/seer/geomap.rb
@@ -90,8 +90,7 @@ module Seer
 
     def data_table #:nodoc:
       @data_table = []
-      data.each_with_index do |datum, column|
-        next unless datum.geocoded?
+      data.select{ |d| d.geocoded? }.each_with_index do |datum, column|
         if data_mode == "markers"
           @data_table << [
             "            data.setValue(#{column}, 0, #{datum.latitude});\r",


### PR DESCRIPTION
i made a little change on the Geomap class.
I got an error, thrown by googles javascript, wich told me i must not use an index of 73.
i figured out that my 73 record is the first one wich is geocoded.

In the loop for building the data_table you check for geocoded records and step to the next record if false...
so the index of the loop is getting higher and higher without building the table.

So my first record in the data_table got an column index of 73...

My Solution:
Before looping through all the records, i select only te geocoded records an loop through them.
So theres no need for further checking.

Greets
Robin
